### PR TITLE
Module verwijderen uit leerroute

### DIFF
--- a/LerenOpMaat/LOM.Client/components/SemesterModule.js
+++ b/LerenOpMaat/LOM.Client/components/SemesterModule.js
@@ -1,7 +1,8 @@
 export default class SemesterModule {
-    constructor(modules, onModuleSelect) {
+    constructor(modules, onModuleSelect, onUnassign = null) { // onUnassign is optioneel
         this.modules = modules;
         this.onModuleSelect = onModuleSelect;
+        this.onUnassign = onUnassign; // Callback voor reset
     }
 
     render() {
@@ -18,6 +19,12 @@ export default class SemesterModule {
             moduleName.textContent = module.description;
             tile.appendChild(moduleName);
 
+            const unassignIcon = document.createElement('span');
+            unassignIcon.classList.add('material-icons', 'module-icon');
+            unassignIcon.textContent = 'X';
+            unassignIcon.title = `Module ${module.description} ontkoppelen`;
+            tile.appendChild(unassignIcon);
+
             const infoIcon = document.createElement('span');
             infoIcon.classList.add('material-icons', 'module-icon');
             infoIcon.textContent = 'i';
@@ -30,6 +37,12 @@ export default class SemesterModule {
 
             tile.addEventListener('click', () => {
                 this.onModuleSelect(module);
+            });
+
+            // Eventlistener voor unassign
+            unassignIcon.addEventListener('click', (event) => {
+                event.stopPropagation(); // Voorkomt dat de click op de tile wordt getriggerd
+                this.onUnassign(); // Roep de onUnassign callback aan
             });
 
             container.appendChild(tile);

--- a/LerenOpMaat/LOM.Client/components/SemesterModule.js
+++ b/LerenOpMaat/LOM.Client/components/SemesterModule.js
@@ -1,8 +1,7 @@
 export default class SemesterModule {
-    constructor(modules, onModuleSelect, onUnassign = null) { // onUnassign is optioneel
+    constructor(modules, onModuleSelect) {
         this.modules = modules;
         this.onModuleSelect = onModuleSelect;
-        this.onUnassign = onUnassign; // Callback voor reset
     }
 
     render() {
@@ -19,17 +18,13 @@ export default class SemesterModule {
             moduleName.textContent = module.description;
             tile.appendChild(moduleName);
 
-            const unassignIcon = document.createElement('span');
-            unassignIcon.classList.add('material-icons', 'module-icon');
-            unassignIcon.textContent = 'X';
-            unassignIcon.title = `Module ${module.description} ontkoppelen`;
-            tile.appendChild(unassignIcon);
-
-            const infoIcon = document.createElement('span');
-            infoIcon.classList.add('material-icons', 'module-icon');
-            infoIcon.textContent = 'i';
-            infoIcon.title = `ga naar ${module.description}`;
-            tile.appendChild(infoIcon);
+            if (module.name !== "Geen Keuze") {
+                const infoIcon = document.createElement('span');
+                infoIcon.classList.add('material-icons', 'module-icon');
+                infoIcon.textContent = 'i';
+                infoIcon.title = `ga naar ${module.description}`;
+                tile.appendChild(infoIcon);
+            }
 
             const moduleDescription = document.createElement('p');
             moduleDescription.textContent = module.name;
@@ -37,12 +32,6 @@ export default class SemesterModule {
 
             tile.addEventListener('click', () => {
                 this.onModuleSelect(module);
-            });
-
-            // Eventlistener voor unassign
-            unassignIcon.addEventListener('click', (event) => {
-                event.stopPropagation(); // Voorkomt dat de click op de tile wordt getriggerd
-                this.onUnassign(); // Roep de onUnassign callback aan
             });
 
             container.appendChild(tile);

--- a/LerenOpMaat/LOM.Client/components/semester-card.js
+++ b/LerenOpMaat/LOM.Client/components/semester-card.js
@@ -15,19 +15,20 @@ export default async function SemesterCard({ semester, module, locked = false })
   const fragment = template.content.cloneNode(true);
   const button = fragment.querySelector("#select-module");
 
+  //Deze gaan wij ook aanpassen later als wij een DB hebben
   if (!locked && button) {
     button.addEventListener("click", async () => {
-      const selectedModule = await SemesterChoice();
+      const selectedModule = await SemesterChoice(button.textContent.trim());
       if (selectedModule.name !== "Geen Keuze") {
         button.innerHTML = `
-                  ${selectedModule.name} 
-                  <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>                  
-              `;
+              ${selectedModule.name} 
+              <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>
+          `;
       } else {
         button.innerHTML = `
-                  Selecteer je module
-                  <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>
-              `;
+              Selecteer je module
+              <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>
+          `;
       }
     });
   }

--- a/LerenOpMaat/LOM.Client/components/semester-card.js
+++ b/LerenOpMaat/LOM.Client/components/semester-card.js
@@ -1,31 +1,38 @@
 import SemesterChoice from "../views/partials/semester-choice.js";
 
 export default async function SemesterCard({ semester, module, locked = false }) {
-    const template = document.createElement("template");
-    template.innerHTML = `
+  const template = document.createElement("template");
+  template.innerHTML = `
       <div class="semester-card ${locked ? 'locked' : ''}">
         <h3>Semester ${semester}</h3>
         <button id="select-module" class="semester-button btn btn-light border">
           ${module}
-          <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill' }"></i> 
+          <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i> 
         </button>
       </div>
     `;
 
-    const fragment = template.content.cloneNode(true);
-    const button = fragment.querySelector("#select-module");
+  const fragment = template.content.cloneNode(true);
+  const button = fragment.querySelector("#select-module");
 
-    if (!locked && button) {
-        button.addEventListener("click", async () => {
-            const selectedModule = await SemesterChoice();
-            if (selectedModule) {
-                button.innerHTML = `
-                    ${selectedModule.name} 
-                    <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>
-                `;
-            }
-        });
-    }
+  if (!locked && button) {
+    button.addEventListener("click", async () => {
+      const selectedModule = await SemesterChoice();
+      if (selectedModule) {
+        button.innerHTML = `
+                  ${selectedModule.name} 
+                  <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>.
+                  
+              `;
+      } else {
+        // Maak de knop leeg als de selectie wordt gereset
+        button.innerHTML = `
+                  Selecteer een module
+                  <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>
+              `;
+      }
+    });
+  }
 
-    return fragment;
+  return fragment;
 }

--- a/LerenOpMaat/LOM.Client/components/semester-card.js
+++ b/LerenOpMaat/LOM.Client/components/semester-card.js
@@ -18,15 +18,14 @@ export default async function SemesterCard({ semester, module, locked = false })
   if (!locked && button) {
     button.addEventListener("click", async () => {
       const selectedModule = await SemesterChoice();
-      if (selectedModule) {
+      if (selectedModule.name !== "Geen Keuze") {
         button.innerHTML = `
                   ${selectedModule.name} 
                   <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>                  
               `;
       } else {
-        // Maak de knop leeg als de selectie wordt gereset
         button.innerHTML = `
-                  Selecteer een module
+                  Selecteer je module
                   <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>
               `;
       }

--- a/LerenOpMaat/LOM.Client/components/semester-card.js
+++ b/LerenOpMaat/LOM.Client/components/semester-card.js
@@ -21,8 +21,7 @@ export default async function SemesterCard({ semester, module, locked = false })
       if (selectedModule) {
         button.innerHTML = `
                   ${selectedModule.name} 
-                  <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>.
-                  
+                  <i class="bi ${locked ? 'bi-lock-fill' : 'bi-unlock-fill'}"></i>                  
               `;
       } else {
         // Maak de knop leeg als de selectie wordt gereset

--- a/LerenOpMaat/LOM.Client/style/SemesterModule.css
+++ b/LerenOpMaat/LOM.Client/style/SemesterModule.css
@@ -50,11 +50,3 @@
     color: black;
     font-family: 'Courier', sans-serif;
 }
-
-.module-icon:first-of-type {
-    right: 28px;
-}
-
-.module-icon:last-of-type {
-    right: 60px;
-}

--- a/LerenOpMaat/LOM.Client/style/SemesterModule.css
+++ b/LerenOpMaat/LOM.Client/style/SemesterModule.css
@@ -51,4 +51,10 @@
     font-family: 'Courier', sans-serif;
 }
 
-  
+.module-icon:first-of-type {
+    right: 28px;
+}
+
+.module-icon:last-of-type {
+    right: 60px;
+}

--- a/LerenOpMaat/LOM.Client/views/partials/semester-choice.js
+++ b/LerenOpMaat/LOM.Client/views/partials/semester-choice.js
@@ -8,10 +8,9 @@ let modulesData = [];
 let selectedCategories = [];
 let selectedCategory;
 
-export default async function SemesterChoice() {
+export default async function SemesterChoice(selectedModuleName = "Selecteer je module") {
     // Hardcoded data for 4 semester modules
     modulesData = [
-        { name: 'Geen Keuze', description: 'Geen Keuze' },
         { name: 'Introduction to Programming', description: 'Introduction to Programming', Category: 'SE' },
         { name: 'Web Development Basics', description: 'Web Development Basics', Category: 'BIM' },
         { name: 'Data Structures and Algorithms', description: 'Data Structures and Algorithms', Category: 'IDNS' },
@@ -28,6 +27,11 @@ export default async function SemesterChoice() {
         { name: 'Database Management Systems', description: 'Database Management Systems', Category: 'IDNS' }
     ];
 
+    //Deze is omdat alles hardcoded is, maar later als wij een DB hebben
+    //dan wordt alles uit de koppel tabel opgehaald
+    if (selectedModuleName !== "Selecteer je module") {
+        modulesData.unshift({ name: 'Geen Keuze', description: 'Geen Keuze' });
+    }
 
     // Create the SemesterModules component with the hardcoded data
     const semesterModules = new SemesterModule(

--- a/LerenOpMaat/LOM.Client/views/partials/semester-choice.js
+++ b/LerenOpMaat/LOM.Client/views/partials/semester-choice.js
@@ -11,6 +11,7 @@ let selectedCategory;
 export default async function SemesterChoice() {
     // Hardcoded data for 4 semester modules
     modulesData = [
+        { name: 'Geen Keuze', description: 'Geen Keuze' },
         { name: 'Introduction to Programming', description: 'Introduction to Programming', Category: 'SE' },
         { name: 'Web Development Basics', description: 'Web Development Basics', Category: 'BIM' },
         { name: 'Data Structures and Algorithms', description: 'Data Structures and Algorithms', Category: 'IDNS' },
@@ -24,7 +25,6 @@ export default async function SemesterChoice() {
         { name: 'Data Structures and Algorithms', description: 'Data Structures and Algorithms', Category: 'BIM' },
         { name: 'Database Management Systems', description: 'Database Management Systems', Category: 'IDNS' },
         { name: 'Data Structures and Algorithms', description: 'Data Structures and Algorithms', Category: 'BIM' },
-        { name: 'Database Management Systems', description: 'Database Management Systems', Category: 'IDNS' },
         { name: 'Database Management Systems', description: 'Database Management Systems', Category: 'IDNS' }
     ];
 
@@ -35,9 +35,6 @@ export default async function SemesterChoice() {
         (selectedModule) => {
             mijnPopup.close(selectedModule); // Sluit popup met geselecteerde module
             return selectedModule;
-        },
-        () => {
-            mijnPopup.close(null); // Sluit popup en reset selectie
         }
     );
 
@@ -90,8 +87,7 @@ function showFilter(Data) {
         });
 
         filterDropdown.appendChild(searchInput);
-
-        const categories = ['Alles', ...new Set(Data.map(m => m.Category))];
+        const categories = ['Alles', ...new Set(Data.filter(m => m.name !== 'Geen Keuze').map(m => m.Category))];
         categories.forEach(category => {
             const option = document.createElement('div');
             option.textContent = category;
@@ -179,7 +175,8 @@ function closeFilterDropdown(event) {
 }
 
 function filterData(searchTerm = '') {
-    let filtered = modulesData;
+    //Geen Keuze niet filteren
+    let filtered = modulesData.filter(m => m.name !== 'Geen Keuze');
 
     if (selectedCategories.length > 0) {
         filtered = filtered.filter(m => selectedCategories.includes(m.Category));
@@ -191,6 +188,9 @@ function filterData(searchTerm = '') {
             m.description.toLowerCase().includes(searchTerm)
         );
     }
+
+    //doe 'Geen Keuze' altijd als eerste optie
+    filtered.unshift({ name: 'Geen Keuze', description: 'Geen Keuze' });
     let popupWidth = 0;
     popupWidth = mijnPopup.popup.getBoundingClientRect().width - 58;
 

--- a/LerenOpMaat/LOM.Client/views/partials/semester-choice.js
+++ b/LerenOpMaat/LOM.Client/views/partials/semester-choice.js
@@ -27,13 +27,19 @@ export default async function SemesterChoice() {
         { name: 'Database Management Systems', description: 'Database Management Systems', Category: 'IDNS' },
         { name: 'Database Management Systems', description: 'Database Management Systems', Category: 'IDNS' }
     ];
-    
+
 
     // Create the SemesterModules component with the hardcoded data
-    const semesterModules = new SemesterModule(modulesData, (selectedModule) => {
-        mijnPopup.close(selectedModule);
-        return selectedModule;
-    });
+    const semesterModules = new SemesterModule(
+        modulesData,
+        (selectedModule) => {
+            mijnPopup.close(selectedModule); // Sluit popup met geselecteerde module
+            return selectedModule;
+        },
+        () => {
+            mijnPopup.close(null); // Sluit popup en reset selectie
+        }
+    );
 
 
     mijnPopup = new Popup({


### PR DESCRIPTION
Als student kan ik een module verwijderen uit mijn leerroute, zodat ik een wijziging kan maken aan mijn leerroute.

1-een "Geen keuze" blok toegevoegd.
![image](https://github.com/user-attachments/assets/9046677c-1155-451c-b55b-5986020d911b)

2- als de blok geklikt wordt dan wordt de module ontkoppelt.

- Het wordt altijd als eerst blok getoond. 
- Wordt niet meegenomen in de filter.